### PR TITLE
movement reliability & pointcloud preloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ For more information on uploading assets, click [here](https://help.glitch.com/k
 
 ### Preloading Assets
 
-While optional, preloading assets ensures that your media is loaded before the user is permitted in the gallery. It also helps reduce redundant loading calls to the same resource, improving performance. At present, this feature is supported for all types of asset files EXCEPT point clouds. All preloading asset tags are placed in the 'Asset Loading Section' of the gallery template.
+While optional, preloading assets ensures that your media is loaded before the user is permitted in the gallery. It also helps reduce redundant loading calls to the same resource, improving performance. All preloading asset tags are placed in the 'Asset Loading Section' of the gallery template.
 
 To prepare your media for preloading, use one of the following tags as appropriate for your media of choice. Replace 'ZZZZ' with the hyperlink you obtained from the 'Uploading Your Work' section. You can use any nickname in place of 'XXXX', the asset tag name; in your A-Frame Entity Tags (see the A-Frame Entity Tag Guide section), replace the src attribute value "#YYYY" with "#XXXX", where 'XXXX' is the asset tag name you invented. For example, if my tag name was 'catSound', then the 'src' attribute would look like `src="#catSound"`.
 
@@ -200,7 +200,7 @@ To prepare your media for preloading, use one of the following tags as appropria
 XXXX - an identifying nickname for the asset (no spaces)
 Z - the hyperlink to the asset, from the Assets folder in your folder hierarchy
 
-Unless the asset is video, audio, or image, use the a-asset-item tag.
+Unless the asset is video, audio, pointcloud, or image, use the a-asset-item tag.
 
 If you want sound to play in your scene as background music instead of positional audio, add the following attributes:
 autoplay - play the media automatically on startup
@@ -209,6 +209,7 @@ loop="true" - start the audio again when it finishes
 
 <video id="XXXX" src="ZZZZ" crossorigin="anonymous" ></video>             
 <audio id="XXXX" src="ZZZZ" crossorigin="anonymous" ></audio>  
+<pointcloud id="XXXX" src="ZZZZ" crossorigin="anonymous" ></pointcloud>  
 <img id="XXXX" src="ZZZZ" crossorigin="anonymous" ></img> 
 <a-asset-item id="XXXX" src="ZZZZ" crossorigin="anonymous" ></a-asset-item>  
 ```
@@ -290,18 +291,18 @@ rotation - Euler rotation of model (x,y,z)
 
 ### Staging Point Clouds
 
-At this time, only point clouds in PLY format are supported. Preloading tags are not supported for point clouds. An example is provided in our Gallery Template.
+At this time, only point clouds in PLY format are supported.  An example is provided in our Gallery Template.
 
 ```
 <!-- Point cloud
-src - Hyperlink to PLY asset 
+src - Hyperlink or preloading tag to PLY asset 
 scale - Scale of cloud (x,y,z)
 position - Position of cloud from origin (x,y,z) 
 rotation - Euler rotation of cloud (x,y,z)
 size - Size of points in cloud
 -->
 <a-pointcloud 
-        src="YYYY        
+        src="#YYYY        
         scale="1 1 1"     
         position="0 0 0"  
         rotation="0 0 0"   

--- a/public/gallery_template.html
+++ b/public/gallery_template.html
@@ -50,12 +50,15 @@
     <script src="https://kit.fontawesome.com/f3fbe8f644.js" crossorigin="anonymous"></script>
 
     <!-- A-FRAME FEATURES (for gallery)-->
+    
     <!-- A-Frame plugin -->
-    <script src="https://aframe.io/releases/1.2.0/aframe.min.js"></script>
-    <!--   Move on mobile   -->
-    <script src="https://rawgit.com/Ctrl-Alt-Zen/aframe-mobile-controls/master/components/twoway-motion/twoway-motion.js"></script>
+    <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script>
+    
+    <!--   Move on mobile -->
+    <script src="https://cdn.jsdelivr.net/gh/vulture-boy/aframe-mobile-controls/components/twoway-motion/twoway-motion.js"></script>
+
     <!--   Network Functionality Plugins   -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.slim.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.4.0/socket.io.slim.js"></script>
     <script src="https://unpkg.com/networked-aframe@^0.7.1/dist/networked-aframe.min.js"></script>
 
     <!--   Pointcloud Plugin   -->
@@ -242,6 +245,12 @@
           crossorigin="anonymous" 
           src="https://cdn.glitch.me/06e25459-7547-47e5-9d1d-9ea50f5cb1df%2Farrow.mtl?v=1638817282798"
         ></a-asset-item>
+        
+        <pointcloud
+          id="dragonPLY"
+          crossorigin="anonymous" 
+          src="https://cdn.glitch.com/06e25459-7547-47e5-9d1d-9ea50f5cb1df%2FDragon_v14_resampled.ply?v=1630007840857"
+        ></pointcloud>
 
 
      <!--****************************************************************-->
@@ -257,7 +266,7 @@
             
             <!-- 'Tadpole' Avatar -->
             <a-entity
-                scale="0.5 0.5 0.5"      
+                scale="0.5 0.5 0.5" 
                 >
                 <a-entity
                   class="player"
@@ -289,30 +298,25 @@
       </a-assets>
 
       <!-- Player/User entity -->
-      <a-entity
-        id = "rig"
-        class = "rig"
-        networked="template:#avatar-template;attachTemplateToLocal:false;"
-        movement-controls="fly: true; "
-        spawn-in-circle="radius:3"
-        position="0 0 0"
-        rotation = "0 0 0"
-        >
         <a-entity
           id="player"
           class="player"
-          camera
+          networked="template:#avatar-template;attachTemplateToLocal:false;"
+          camera  
           look-controls
-          rotation="0 45 0"
+          wasd-controls="acceleration:60; fly: true;"
+          twoway-motion="speed: 35;"
+          position="0 2 0"
+          spawn-in-circle="radius:3"
         >
           <!-- Important: Syncs with cone in avatar-template to provide syncronous color.
            See NAF schema near bottom of page for details on which player properties are synced on the network. -->
           <a-cone class="head"
             visible="false"
+            color="#DDDDDD"
             random-color="min: 0.0 0.0 0.0; max: 1.0 1.0 1.0"
           ></a-cone>
         </a-entity>
-      </a-entity>
       
       <!-- Play-On-Click Trigger-->
       <a-entity play-on-click></a-entity>
@@ -364,16 +368,6 @@
       <!--   SCENE CONTENT SECTION  -->
       <!-- Any entities you create should be placed here -->
       
-      <!-- Environment Group 
-       You can modify the position, scale, and rotation of this to affect all
-          entities between its tags (its children)
-        This can be handy when you need to adjust the entire world rather than adjusting 
-          individual objects manually.
-      -->
-      <a-entity
-        id="environmentGroup"
-        position="0 -2 0"
-                >
         <!-- PLINTH 
       Plinth is a flat cylinder. 
       To change color, replace grey with an html color name or code. Code will be a #FFFFFF format.
@@ -388,7 +382,7 @@
 
         <!-- Sample Pointcloud  with a rotational element-->
         <a-pointcloud
-          src="https://cdn.glitch.com/06e25459-7547-47e5-9d1d-9ea50f5cb1df%2FDragon_v14_resampled.ply?v=1630007840857"
+          src="#dragonPLY"
           scale="1 1 1"
           position="0 2 0"
           size="0.002"
@@ -469,7 +463,6 @@
           rotation="0 0 0" 
           scale="1 1 1">
         </a-obj-model>
-      </a-entity>
       
     </a-scene> <!-- End of Scene; any object tags placed after this won't show up. -->
 
@@ -497,10 +490,7 @@
         template: "#avatar-template",
         components: [
           "position",
-          {
-            selector: ".player",
-            component: "rotation",
-          },
+          "rotation",
           {
             selector: ".head",
             component: "material",

--- a/public/js/basic_components.js
+++ b/public/js/basic_components.js
@@ -84,7 +84,7 @@ AFRAME.registerComponent('hotspot-hyperlink', {
     url: {type: 'string', default: "/index.html"},  // Hyperlink to open
     detectionBox: {type: 'vec3', default: {x:1, y:1, z:1}},    // Region of detection relative to this entity
     target: {type: 'string', default: "_self"},  // Use "_blank" for a new window
-    teleportee: {type: 'string', default: "rig"} // Object to trigger hyperlink
+    teleportee: {type: 'string', default: "player"} // Object to trigger hyperlink
   },
   
   init: function() {
@@ -101,7 +101,8 @@ AFRAME.registerComponent('hotspot-hyperlink', {
   tick: function(time, timeDelta) {
     // Open the url if the player is in the hotspot & popups are permitted
     if (!this.windowOpened && this.inDetectionBox() ) {
-      window.open(this.data.url, this.data.target).focus(); 
+      var win = window.open(this.data.url, this.data.target);
+      if (win != null) {win.focus();}
       this.windowOpened = true;  // Prevents infinite window opening; one-use
     }
   },
@@ -144,7 +145,7 @@ AFRAME.registerComponent('hotspot-teleport', {
   schema: {
     detectionBox: {type: 'vec3', default: {x:1, y:1, z:1}},    // Region of detection relative to this entity
     targetPos: {type: 'vec3', default: {x:0, y:0, z:0}},  // Use "_blank" for a new window
-    teleportee: {type: 'string', default: "rig"} // Object to teleport
+    teleportee: {type: 'string', default: "player"} // Object to teleport
   },
   
   init: function() {

--- a/public/js/spawn-in-circle.component.js
+++ b/public/js/spawn-in-circle.component.js
@@ -4,8 +4,7 @@
 
 AFRAME.registerComponent('spawn-in-circle', {
   schema: {
-    radius: {type: 'number', default: 1},
-    model: {type: 'string', default: 'player'}
+    radius: {type: 'number', default: 1}
   },
 
   init: function() {
@@ -19,8 +18,10 @@ AFRAME.registerComponent('spawn-in-circle', {
     // console.log('world point', worldPoint);
 
     var angleDeg = angleRad * 180 / Math.PI;
-    var angleToCenter = angleDeg + 180;
-    var angleRad = angleToCenter * Math.PI /180;
+    var angleToCenter = -1 * angleDeg + 90;
+    angleRad = THREE.Math.degToRad(angleToCenter);
+    el.object3D.rotation.set(0, angleRad, 0);
+    // console.log('angle deg', angleDeg);
   },
 
   getRandomAngleInRadians: function() {


### PR DESCRIPTION
Removed the arm wrestling between two movement components, fixed an issue with twoway-motion component where it wouldn't be able to find its own name, and discovered that the a-frame point cloud component does indeed have a dedicated preloader & updated the docs & template accordingly.