### PR TITLE
fullscreen, swim controls & animation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # OCAD University Open WebXR Template for A-Frame
-Updated 2022-04-28
+Updated 2022-04-29
 
 OCAD University Open WebXR is a free and open-source project template for staging and showcasing digital work in an Extended Reality (XR) space. The WebXR platform uses [A-Frame](https://aframe.io), an open-source library for implementing 3D and VR content in the browser with [HTML](https://html.com/). It is built on [ThreeJS](https://threejs.org), a JavaScript library for rendering 3D models on the web. Our Open WebXR Gallery template is officially hosted [on Glitch.com](https://glitch.com/~ocadu-open-webxr), with stable versions mirrored to [GitHub](https://github.com/ocadwebxr/ocadu-open-webxr). You may be interested in visiting [our student gallery](https://glitch.com/~ocadu-web-xr).
 
@@ -46,7 +46,7 @@ This is one of three projects developed in parallel by OCAD University and York 
     * Ground
     * Particles
     * Avatars
-3. Custom A-Frame Components
+3. Animation & Custom A-Frame Components
 
 <b>Asset Acknowledgements & Licensing</b>
 
@@ -450,17 +450,29 @@ That being said, you should be able to experimentally make minor changes to the 
 
 ---------
 
-## Custom A-Frame Components
+## Animation & Custom A-Frame Components
 
 Components can be added to all manners of A-Frame entities to extend their functionality. 
-We can transform objects that we place in our scenes by changing their scale, rotation and position, but if we wanted to, say, have an object rotate over time or have an object scale to a particular size over time, we need to use our own components.
+We can transform objects that we place in our scenes by changing their scale, rotation and position.
 
-If we wanted to have a cube spin over time, we could use this code in our gallery:
+A-Frame has a built-in method to do this: the 'animation' component, which allows you to specify a property you want to modify from a starting value to a new value. The component allows you to change the behaviour in which the animation is performed as well. For full details on how to manipulate the animation component, see the [A-Frame documentation page on animation](https://aframe.io/docs/1.3.0/components/animation.html).
+
+The following example shows how to create a box that rotates in the y axis in a full loop every two seconds (2000 milliseconds) and scales back and forth between 10x its initial size:
+```
+<a-box
+  animation="property: rotation; to: 0 360 0; dur: 2000; loop: true"
+  animation__scale="property: scale; to: 1 1 10; dur: 16000; easing: linear; dir: alternate; loop: true"
+  
+>
+</a-box>
+```
+Note the use of the double underscore. Any phrase can follow a double underscore, which allows you to add multiple copies of a component to a single entity.
+
+For more control over the behaviour of our objects, we can use custom components or create our own components.
+
+The following box entity rotates in three dimensions indefinitely:
 ```
 <a-box 
-  color="tomato" 
-  position="3 2 3"
-  depth="0.5" height="0.5" width="0.5"
   rotate-time="rotationSpeed: 0.01 -0.01 0.02"
   >
 </a-box>
@@ -468,7 +480,7 @@ If we wanted to have a cube spin over time, we could use this code in our galler
 Notice the 'rotate-time' component? This is one of several basic components provided in our `basic_components.js` that can be added to your primitives, point-clouds, etc. without any major scripting work on your part. You can browse this JS document to find more components that have been prepared for WebXR, or experiment with the component examples we have prepared in the gallery template.
 You may also be interested in the components provided by [aframe-randomizer-components](https://www.npmjs.com/package/aframe-randomizer-components); we included this in the template to provide random colours to the avatars, but you might find some of its properties to be useful for your own projects.
 
-You can add as many compatible components to your objects as you'd like, but if you want to implement more complicated behaviours, you may want to give the [A-Frame component documentation](https://aframe.io/docs/1.2.0/core/component.html) a review and be prepared to work with a little bit of JavaScript.
+You can add as many compatible components to your objects as you'd like, but if you want to implement more complicated behaviours, you may want to give the [A-Frame component documentation](https://aframe.io/docs/1.3.0/core/component.html) a review and be prepared to work with a little bit of JavaScript.
 
 You can also check out [NPM's listing of A-Frame components](https://www.npmjs.com/search?q=aframe-component&page=0&perPage=20), including [a component for creating portals](https://www.npmjs.com/package/aframe-portals)! Follow the instructions with each component to install and use them with your project.
 
@@ -491,6 +503,8 @@ This project incorporates the following JavaScript libraries:
 - [A-Frame Mobile Controls: Twoway Motion](https://github.com/Ctrl-Alt-Zen/aframe-mobile-controls/tree/master/components/twoway-motion)
 - [A-Frame Point Cloud Component](https://github.com/daavoo/aframe-pointcloud-component)
 - [A-Frame Randomizer Components](https://www.npmjs.com/package/aframe-randomizer-components)
+- [A-Frame Particle System Component](https://github.com/IdeaSpaceVR/aframe-particle-system-component)
+- [DepthKit for A-Frame](https://github.com/juniorxsound/DepthKit-A-Frame)
 - [Networked A-Frame](https://www.npmjs.com/package/networked-aframe)
 - [Bootstrap](https://getbootstrap.com/)
 - [Font Awesome](https://fontawesome.com/)

--- a/public/controls.html
+++ b/public/controls.html
@@ -2,14 +2,14 @@
 <p class="overflow-auto">
   <h3>Controls</h3>
   <u>Desktop</u><br>
-  Use the Arrow Keys or WASD keys to move forwards, backwards, side to side <br> <br>Click and Drag to Pan. 
+  Use the Arrow Keys or WASD keys to move forwards, backwards, side to side relative to the direction the camera faces. Click and Drag to move the camera view. <br><br> Note: there is a known bug where sometimes movement will be locked to the ground; try refreshing.
 
   <br><br><u>Mobile</u><br>
   Touch the screen for forward motion, drag left or right to rotate left or right. Tilt your device to freely look around.
 
   <br><br>(In your browser, ensure that Motion Sensors is Enabled under Settings - Site Settings.)
 
-  <br><br><br>Click the 'VR' or 'AR' icon to experience the gallery space with a compatible headset device. Headset controls vary by device but generally require external controllers to navigate spaces.
+  <br><br><br>Click the 'VR' icon to experience the gallery space with a compatible headset device. Headset controls vary by device but generally require external controllers to navigate spaces. Some devices also support 'AR'.
 
 </p>
 

--- a/public/gallery_template.html
+++ b/public/gallery_template.html
@@ -53,8 +53,12 @@
     
     <!-- A-Frame plugin (>1.1.0) -->
     <script src="https://aframe.io/releases/1.3.0/aframe.min.js"></script> 
+    
     <!-- Old version (0.8.2) for Depthkit support. Has several bugs that may impact experience, use only if necessary
-    <script src="https://aframe.io/releases/0.8.2/aframe.min.js"></script>  -->
+    <script src="https://aframe.io/releases/0.8.2/aframe.min.js"></script> -->
+    
+    <!-- Substitute movement script adding Sink-Float controls. (Also adds A-Frame 1.3.0 controls to 0.8.2) -->
+    <script src="/js/wasd-controls-alt.js"></script>
     
     <!--   Move on mobile -->
     <script src="https://cdn.jsdelivr.net/gh/vulture-boy/aframe-mobile-controls/components/twoway-motion/twoway-motion.js"></script>
@@ -80,14 +84,10 @@
     <!-- Note: must add play-on-click-video components to video / play-on-click-audio components to audio -->
     <script src="/js/play-on-click.js"></script>
     
-    <!-- Movement Controls-->
-    <script src="https://cdn.jsdelivr.net/gh/donmccurdy/aframe-extras@v6.1.1/dist/aframe-extras.min.js"></script>
+    <!-- Particle System (A-Frame >1.1.0) 
+    <script src="https://ideaspacevr.github.io/aframe-particle-system-component/dist/aframe-particle-system-component.js"></script> -->
     
-    
-    <!-- Particle System (A-Frame >1.1.0) -->
-    <script src="https://ideaspacevr.github.io/aframe-particle-system-component/dist/aframe-particle-system-component.js"></script> 
-    
-    <!-- Volumetric Video & Particles (A-Frame 0.8.2; requires downgrade) 
+    <!-- Volumetric Video & Particles (A-Frame 0.8.2; requires downgrade)
     <script src="https://cdn.jsdelivr.net/gh/juniorxsound/DepthKit-A-Frame/dist/aframe.depthkit.js"></script> 
     <script src="https://unpkg.com/aframe-particle-system-component@1.1.x/dist/aframe-particle-system-component.min.js"></script> -->
 
@@ -109,7 +109,6 @@
       <link rel="stylesheet" href="/overlay_style.css"> <!--Style Sheet for Overlay-->
       <script src="/js/infoOverlay.js"></script> <!-- General Overlay functions -->
       <script src="/js/gallerymap.js"></script>  <!-- Sitemapping -->
-
       <script src="/js/sitemap_overlay.js"></script>  <!-- Scripts for sitemap functions  -->
     
       <!--Overlay content begins here-->
@@ -117,10 +116,11 @@
       
       <!-- Navigation Buttons -->
       <div id="overlayBtns">
-        <i class="fas fa-info-circle fa-3x" id="infoButton" onclick="toggleElement('infoPopup')"></i> <!-- Information Pop-Up Button -->
-        <a id="ctrlButton"  onclick="toggleElement('ctrlPopup')"><i class="fas fa-gamepad fa-3x"></i></a>  <!-- Controls Pop-Up Button -->
-        <a id="mapButton"  onclick="toggleElement('mapPopup');"><i class="fas fa-map fa-3x"></i></a> <!-- Site Map Pop-Up Button -->
-        <a id="homeButton" href="/index.html" target="_blank"><i class="fas fa-home fa-3x"></i></a> <!--Home Button-->
+        <a id="homeButtonBox" href="/index.html" target="_blank"><i id="homeButton" class="fas fa-home fa-3x"></i></a> <!--Home Button-->
+        <a id="infoButtonBox"><i class="fas fa-info-circle fa-3x" id="infoButton" onclick="toggleElement('infoPopup')"></i></a> <!-- Information Pop-Up Button -->
+        <a id="ctrlButtonBox" onclick="toggleElement('ctrlPopup');"><i id="ctrlButton" class="fas fa-gamepad fa-3x"></i></a>  <!-- Controls Pop-Up Button -->
+        <a id="mapButtonBox" onclick="toggleElement('mapPopup');"><i id="mapButton" class="fas fa-map fa-3x"></i></a> <!-- Site Map Pop-Up Button -->
+        <a id="fullButtonBox" onclick="toggleFullscreen();"><i id="fullButton" class="fas fa-expand fa-3x"></i></a>
       </div>
         <!-- Replaces home link with designated link in gallerymap.js -->
         <script>swapHome();</script>
@@ -311,7 +311,8 @@
           networked="template:#avatar-template;attachTemplateToLocal:false;"
           camera  
           look-controls
-          wasd-controls="acceleration:60; fly: true;"
+          wasd-controls-alt="acceleration:60; fly: true;"
+          sink-float
           twoway-motion="speed: 35;"
           position="0 2 0"
           spawn-in-circle="radius:3"
@@ -351,7 +352,8 @@
       <!-- Skybox for the gallery. 
       Image is optional. Image will not be visible if color is black (#000000) -->
       <!-- <img id="sky" src="YYYY"  crossorigin="anonymous" /> -->
-      <a-sky src="#sky" color="#000000" rotation="0 -90 0"></a-sky>
+      <!-- <a-sky src="#sky" color="#000000" rotation="0 -90 0"></a-sky> -->
+      <a-sky color="#000000"></a-sky>
 
       <!--     Ground      -->
       <!-- Ground plane affected by skybox. 
@@ -387,23 +389,23 @@
           position="0 1 0"
         ></a-cylinder>
 
-        <!-- Sample Pointcloud  with a rotational element-->
+        <!-- Sample Pointcloud  with a 1D rotational element-->
         <a-pointcloud
           src="#dragonPLY"
           scale="1 1 1"
           position="0 2 0"
           size="0.002"
-          rotate-time="rotationSpeed: 0 0.02 0"
+          animation="property: rotation; to: 0 360 0; dur: 12000; easing: linear; loop: true"
         >
         </a-pointcloud>
 
-        <!-- Rotation / Changing Scale Example -->
+        <!-- 3D Rotation Example -->
         <a-box 
           color="tomato" 
           position="3 2 3"
           depth="0.5" height="0.5" width="0.5"
           rotate-time="rotationSpeed: 0.01 -0.01 0.02"
-          scale-time="scaleSpeed: 0 0 0.000001"
+          animation__scale="property: scale; to: 1 1 10; dur: 16000; easing: linear; dir: alternate; loop: true"
           >
         </a-box>
 
@@ -454,7 +456,6 @@
           height="3"     
           rotation="0 135 0"
           position="-3 3 3"
-
           >  
         </a-video>
 

--- a/public/js/sitemap_overlay.js
+++ b/public/js/sitemap_overlay.js
@@ -123,3 +123,40 @@ function neighbourNavigation() {
   
   // Note: nothing will be prepared if the ID match is not found
 }
+
+// Fullscreen toggle function
+var full = false;
+function toggleFullscreen() {
+  if (full) {
+    closeFullscreen();
+  } else {
+    openFullscreen();
+  }
+  full = !full;
+}
+
+// see https://www.w3schools.com/howto/howto_js_fullscreen.asp
+function openFullscreen() {
+  var elem = document.documentElement;
+  
+  if (elem.requestFullscreen) {
+    elem.requestFullscreen();
+  } else if (elem.webkitRequestFullscreen) { /* Safari */
+    elem.webkitRequestFullscreen();
+  } else if (elem.msRequestFullscreen) { /* IE11 */
+    elem.msRequestFullscreen();
+  }
+}
+
+/* Close fullscreen */
+function closeFullscreen() {
+  var elem = document.documentElement;
+  
+  if (document.exitFullscreen) {
+    document.exitFullscreen();
+  } else if (document.webkitExitFullscreen) { /* Safari */
+    document.webkitExitFullscreen();
+  } else if (document.msExitFullscreen) { /* IE11 */
+    document.msExitFullscreen();
+  }
+}

--- a/public/js/wasd-controls-alt.js
+++ b/public/js/wasd-controls-alt.js
@@ -1,0 +1,292 @@
+/*
+Originally written by A-Frame Community, modified by Tyson Moll
+
+This is a modified version of the built-in wasd-controls.js file in A-Frame.
+It currently has not been accepted to the active A-Frame build.
+https://github.com/vulture-boy/aframe/blob/master/src/components/wasd-controls.js
+
+The purpose is to to allow users to dynamically change their axes during runtime.
+
+I made this to add the 'sink-float' component which is included at the bottom of this document,
+so that users can change between moving forward and moving vertically.
+*/
+
+var KEYCODE_TO_CODE = {
+  // Tiny KeyboardEvent.code polyfill.
+  KEYCODE_TO_CODE: {
+    '38': 'ArrowUp',
+    '37': 'ArrowLeft',
+    '40': 'ArrowDown',
+    '39': 'ArrowRight',
+    '87': 'KeyW',
+    '65': 'KeyA',
+    '83': 'KeyS',
+    '68': 'KeyD'
+  }
+};
+
+function bind (fn, ctx/* , arg1, arg2 */) {
+  return (function (prependedArgs) {
+    return function bound () {
+      // Concat the bound function arguments with those passed to original bind
+      var args = prependedArgs.concat(Array.prototype.slice.call(arguments, 0));
+      return fn.apply(ctx, args);
+    };
+  })(Array.prototype.slice.call(arguments, 2));
+};
+
+function shouldCaptureKeyEvent (event) {
+  if (event.metaKey) { return false; }
+  return document.activeElement === document.body;
+};
+
+var CLAMP_VELOCITY = 0.00001;
+var MAX_DELTA = 0.2;
+var KEYS = [
+  'KeyW', 'KeyA', 'KeyS', 'KeyD',
+  'ArrowUp', 'ArrowLeft', 'ArrowRight', 'ArrowDown'
+];
+
+/**
+ * WASD component to control entities using WASD keys.
+ */
+AFRAME.registerComponent('wasd-controls-alt', {
+  schema: {
+    acceleration: {default: 65},
+    adAxis: {default: 'x', oneOf: ['x', 'y', 'z']},
+    adEnabled: {default: true},
+    adInverted: {default: false},
+    enabled: {default: true},
+    fly: {default: false},
+    wsAxis: {default: 'z', oneOf: ['x', 'y', 'z']},
+    wsEnabled: {default: true},
+    wsInverted: {default: false}
+  },
+
+  init: function () {
+    // To keep track of the pressed keys.
+    this.keys = {};
+    this.easing = 1.1;
+    
+    // NEW
+    this.lastWSAxis = this.data.wsAxis;
+    this.lastADAxis = this.data.adAxis;
+
+    this.velocity = new THREE.Vector3();
+
+    // Bind methods and add event listeners.
+    this.onBlur = bind(this.onBlur, this);
+    this.onContextMenu = bind(this.onContextMenu, this);
+    this.onFocus = bind(this.onFocus, this);
+    this.onKeyDown = bind(this.onKeyDown, this);
+    this.onKeyUp = bind(this.onKeyUp, this);
+    this.onVisibilityChange = bind(this.onVisibilityChange, this);
+    this.attachVisibilityEventListeners();
+  },
+
+  tick: function (time, delta) {
+    var data = this.data;
+    var el = this.el;
+    var velocity = this.velocity;
+
+    if (!velocity[data.adAxis] && !velocity[data.wsAxis] &&
+        isEmptyObject(this.keys)) { return; }
+
+    // Update velocity.
+    delta = delta / 1000;
+    this.updateVelocity(delta);
+
+    if (!velocity[data.adAxis] && !velocity[data.wsAxis]) { return; }
+
+    // Get movement vector and translate position.
+    el.object3D.position.add(this.getMovementVector(delta));
+  },
+
+  remove: function () {
+    this.removeKeyEventListeners();
+    this.removeVisibilityEventListeners();
+  },
+
+  play: function () {
+    this.attachKeyEventListeners();
+  },
+
+  pause: function () {
+    this.keys = {};
+    this.removeKeyEventListeners();
+  },
+
+  updateVelocity: function (delta) {
+    var acceleration;
+    var adAxis;
+    var adSign;
+    var data = this.data;
+    var keys = this.keys;
+    var velocity = this.velocity;
+    var wsAxis;
+    var wsSign;
+
+    adAxis = data.adAxis;
+    wsAxis = data.wsAxis;
+	
+	// NEW: If a control axis was changed, reset its old velocity
+	if (adAxis != this.lastADAxis) {
+		velocity[this.lastADAxis] = 0;		
+		this.lastADAxis = adAxis;
+	}
+	if (wsAxis != this.lastWSAxis) {
+		velocity[this.lastWSAxis] = 0;
+		this.lastWSAxis = wsAxis;
+	}
+
+    // If FPS too low, reset velocity.
+    if (delta > MAX_DELTA) {
+      velocity[adAxis] = 0;
+      velocity[wsAxis] = 0;
+      return;
+    }
+	
+    // https://gamedev.stackexchange.com/questions/151383/frame-rate-independant-movement-with-acceleration
+    var scaledEasing = Math.pow(1 / this.easing, delta * 60);
+    // Velocity Easing.
+    if (velocity[adAxis] !== 0) {
+      velocity[adAxis] = velocity[adAxis] * scaledEasing;
+    }
+    if (velocity[wsAxis] !== 0) {
+      velocity[wsAxis] = velocity[wsAxis] * scaledEasing;
+    }
+
+    // Clamp velocity easing.
+    if (Math.abs(velocity[adAxis]) < CLAMP_VELOCITY) { velocity[adAxis] = 0; }
+    if (Math.abs(velocity[wsAxis]) < CLAMP_VELOCITY) { velocity[wsAxis] = 0; }
+
+    if (!data.enabled) { return; }
+
+    // Update velocity using keys pressed.
+    acceleration = data.acceleration;
+    if (data.adEnabled) {
+      adSign = data.adInverted ? -1 : 1;
+      if (keys.KeyA || keys.ArrowLeft) { velocity[adAxis] -= adSign * acceleration * delta; }
+      if (keys.KeyD || keys.ArrowRight) { velocity[adAxis] += adSign * acceleration * delta; }
+    }
+    if (data.wsEnabled) {
+      wsSign = data.wsInverted ? -1 : 1;
+      if (keys.KeyW || keys.ArrowUp) { velocity[wsAxis] -= wsSign * acceleration * delta; }
+      if (keys.KeyS || keys.ArrowDown) { velocity[wsAxis] += wsSign * acceleration * delta; }
+    }
+  },
+
+  getMovementVector: (function () {
+    var directionVector = new THREE.Vector3(0, 0, 0);
+    var rotationEuler = new THREE.Euler(0, 0, 0, 'YXZ');
+
+    return function (delta) {
+      var rotation = this.el.getAttribute('rotation');
+      var velocity = this.velocity;
+      var xRotation;
+
+      directionVector.copy(velocity);
+      directionVector.multiplyScalar(delta);
+
+      // Absolute.
+      if (!rotation) { return directionVector; }
+
+      xRotation = this.data.fly ? rotation.x : 0;
+
+      // Transform direction relative to heading.
+      rotationEuler.set(THREE.Math.degToRad(xRotation), THREE.Math.degToRad(rotation.y), 0);
+      directionVector.applyEuler(rotationEuler);
+      return directionVector;
+    };
+  })(),
+
+  attachVisibilityEventListeners: function () {
+    window.oncontextmenu = this.onContextMenu;
+    window.addEventListener('blur', this.onBlur);
+    window.addEventListener('focus', this.onFocus);
+    document.addEventListener('visibilitychange', this.onVisibilityChange);
+  },
+
+  removeVisibilityEventListeners: function () {
+    window.removeEventListener('blur', this.onBlur);
+    window.removeEventListener('focus', this.onFocus);
+    document.removeEventListener('visibilitychange', this.onVisibilityChange);
+  },
+
+  attachKeyEventListeners: function () {
+    window.addEventListener('keydown', this.onKeyDown);
+    window.addEventListener('keyup', this.onKeyUp);
+  },
+
+  removeKeyEventListeners: function () {
+    window.removeEventListener('keydown', this.onKeyDown);
+    window.removeEventListener('keyup', this.onKeyUp);
+  },
+
+  onContextMenu: function () {
+    var keys = Object.keys(this.keys);
+    for (var i = 0; i < keys.length; i++) {
+      delete this.keys[keys[i]];
+    }
+  },
+
+  onBlur: function () {
+    this.pause();
+  },
+
+  onFocus: function () {
+    this.play();
+  },
+
+  onVisibilityChange: function () {
+    if (document.hidden) {
+      this.onBlur();
+    } else {
+      this.onFocus();
+    }
+  },
+
+  onKeyDown: function (event) {
+    var code;
+    if (!shouldCaptureKeyEvent(event)) { return; }
+    code = event.code || KEYCODE_TO_CODE[event.keyCode];
+    if (KEYS.indexOf(code) !== -1) { this.keys[code] = true; }
+  },
+
+  onKeyUp: function (event) {
+    var code;
+    code = event.code || KEYCODE_TO_CODE[event.keyCode];
+    delete this.keys[code];
+  }
+});
+
+function isEmptyObject (keys) {
+  var key;
+  for (key in keys) { return false; }
+  return true;
+}
+
+AFRAME.registerComponent('sink-float',{
+
+  init: function() {
+    var el = this.el;
+    document.addEventListener('keydown', (event) => {
+      var name = event.key;
+      var code = event.code;
+      
+      if (name === " ") {
+        el.setAttribute('wasd-controls-alt', {wsAxis: 'y', wsInverted: true})
+      }
+    }, false);
+    
+    document.addEventListener('keyup', (event) => {
+      var name = event.key;
+      var code = event.code;
+      
+      if (name === " ") {
+        el.setAttribute('wasd-controls-alt', {wsAxis: 'z', wsInverted: false})
+      }
+    }, false);
+    
+  }
+});

--- a/public/overlay_style.css
+++ b/public/overlay_style.css
@@ -33,6 +33,8 @@ a:active {
 .overlayPanel,
 .overlayPanelCenter {
   /* General Overlay panel attributes */
+  top: 0px;
+  left: 0px;
   position: fixed;
   z-index: 1;
   display: none;
@@ -95,38 +97,44 @@ a:active {
 #infoButton,
 #ctrlButton,
 #mapButton,
-#homeButton {
+#homeButton,
+#fullButton {
   /* Overlay buttons */
   display: inline-block;
   text-align: center;
   position: fixed;
   top: 195px;
-  width: 60px;
+  height: 6%;
+  width: auto;
   right: 20px;
-  color: #ffffffdd;
+  color: #ddddddcc;
   user-select: none;
 }
 
 /* Highlight buttons */
+#homeButton:hover,
 #infoButton:hover,
 #ctrlButton:hover,
 #mapButton:hover,
-#homeButton:hover {
-  color: grey;
+#fullButton:hover {
+  color: #ffffffee;
 }
 
-/* Vertical Button Positioning*/
+/* Vertical Button Positioning (general + 2%)*/
+#homeButton {
+  top: 2%;
+}
 #infoButton {
-  top: 15px;
+  top: 10%;
 }
 #ctrlButton {
-  top: 75px;
+  top: 18%;
+}
+#fullButton {
+  top: 26%;
 }
 #mapButton {
-  top: 135px;
-}
-#homeButton {
-  top: 195px;
+  top: 34%;
 }
 
 /* Buttons for closing panels */


### PR DESCRIPTION
New Updates:
-	Added a full screen button
-	Side icons now scale by screen size (also reordered them slightly)
-	Fixed an issue where the overlay wasn’t aligned to the top left
-	Sink / Float controls added (hold space bar and press W/S)
-	Documentation and template now include the Animation component

There was a bug in A-Frame's core system related to the controls that limited movement in the vertical axis. I extracted the script and resolved the issue; our local copy has the fixed version and I’ve proposed a correction to the A-Frame repo: https://github.com/aframevr/aframe/pull/5050 .
